### PR TITLE
Use 'link' function instead of raw-string

### DIFF
--- a/Templates/DataDefinitionSource.dkt
+++ b/Templates/DataDefinitionSource.dkt
@@ -19,7 +19,7 @@
 	Name = '<%= parentName %> ML Model'
 	Dataset
 	{
-		Loader = '<%= parentName %>MLModelDataProvider'
+		Loader = link(<%= parentName %>MLModelDataProvider)
 	}
 	Input
 	{


### PR DESCRIPTION
The advantage of using the 'Link' function is that the referenced object is automatically added to the calling tree