### PR TITLE
Data provider key as dataoutputtype

### DIFF
--- a/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
+++ b/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
@@ -41,11 +41,16 @@ namespace Genexus.Patterns.MLModel
         #region Outputs
 
         public static string TemplateValueForOutputType(string outputType) {
+            string templateValue = TemplateKeyForOutputType(outputType);
+            return $"{kDataOutputTypeFullName}.{templateValue}";
+        }
+
+        public static string TemplateKeyForOutputType(string outputType) {
             string templateValue = outputType;
             if (templateValue == "Category") {
                 templateValue = "Label";
             }
-            return $"{kDataOutputTypeFullName}.{templateValue}";
+            return templateValue;
         }
 
         #endregion

--- a/Templates/DataProviderSource.dkt
+++ b/Templates/DataProviderSource.dkt
@@ -36,7 +36,7 @@
 			}
 			Output
 			{
-				<%= outColumnType %> = &<%= outValue %>
+				<%= MLModelInstanceHelper.TemplateValueForOutputType(outColumnType) %> = &<%= outValue %>
 			}
 		}
 	}

--- a/Templates/DataProviderSource.dkt
+++ b/Templates/DataProviderSource.dkt
@@ -36,7 +36,7 @@
 			}
 			Output
 			{
-				<%= MLModelInstanceHelper.TemplateValueForOutputType(outColumnType) %> = &<%= outValue %>
+				<%= MLModelInstanceHelper.TemplateKeyForOutputType(outColumnType) %> = &<%= outValue %>
 			}
 		}
 	}


### PR DESCRIPTION
DataProvider's key is generated as a fully-qualified DataOutputType value when it should be the name for the value.