### PR TITLE
Missing ToString on Label output value for DataProvider

### DIFF
--- a/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
+++ b/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
@@ -221,16 +221,29 @@ namespace Genexus.Patterns.MLModel
             return $"{kDataOutputTypeFullName}.{templateValue}";
         }
 
-        public static string TemplateKeyForOutputType(string outputType) {
+        public static string TemplateKeyForOutputType(string outputType) 
+		{
             string templateValue = outputType;
-            if (templateValue == "Category") {
+            if (templateValue == "Category") 
+			{
                 templateValue = "Label";
             }
             return templateValue;
         }
         
+		public static string TemplateKeyForOutputType(OutputElement output)
+		{
+			if (string.IsNullOrEmpty(output?.ColumnType))
+				return "Numeric";
+			return TemplateKeyForOutputType(output?.ColumnType);
+		}
+
 		public static string TemplateValueForOutputAttValue(OutputElement output)
 		{
+			if (output == null)
+			{
+				return "'0'";
+			}
 			if (output.ColumnType == "Numeric")
 			{
 				return $"&{output.Attribute.Name}";

--- a/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
+++ b/GeneXus.Patterns.MLModel/GeneXus.Patterns.MLModel/MLModelInstanceHelper.cs
@@ -228,6 +228,18 @@ namespace Genexus.Patterns.MLModel
             }
             return templateValue;
         }
+        
+		public static string TemplateValueForOutputAttValue(OutputElement output)
+		{
+			if (output.ColumnType == "Numeric")
+			{
+				return $"&{output.Attribute.Name}";
+			}
+			else
+			{
+				return $"&{output.Attribute.Name}.ToString().Trim()";
+			}
+		}
 
 		public static IEnumerable<KeyValuePair<string, string>> EnumerateOutputProperties(OutputElement output)
 		{

--- a/Templates/DataProviderSource.dkt
+++ b/Templates/DataProviderSource.dkt
@@ -9,8 +9,9 @@
 
 <%
 	MLModelInstance instance = new MLModelInstance(Instance);
-	string outColumnType = instance.Output != null ? instance.Output.ColumnType : "Numeric";
-	string outValue = instance.Output != null ? instance.Output.Attribute.Name : "'0'";
+    var output = instance.Output;
+    string outColumnType = output != null ? MLModelInstanceHelper.TemplateKeyForOutputType(output.ColumnType) : "Numeric";
+	string outValue = output != null ? MLModelInstanceHelper.TemplateValueForOutputAttValue(output) : "'0'";
 %>
 
 <Part type="1d8aeb5a-6e98-45a7-92d2-d8de7384e432">
@@ -22,7 +23,7 @@
 	<% 	foreach (var input in instance.Inputs) { %>
 		&<%= input.Attribute.Name %> = <%= input.Attribute.Name %>
 	<% 	} %>
-		&<%= outValue %> = <%= outValue %>
+		&<%= output.Attribute.Name %> = <%= output.Attribute.Name %>
 
 		Data 
 		{
@@ -36,7 +37,7 @@
 			}
 			Output
 			{
-				<%= MLModelInstanceHelper.TemplateKeyForOutputType(outColumnType) %> = &<%= outValue %>
+				<%= outColumnType %> = <%= outValue %>
 			}
 		}
 	}

--- a/Templates/DataProviderSource.dkt
+++ b/Templates/DataProviderSource.dkt
@@ -10,8 +10,8 @@
 <%
 	MLModelInstance instance = new MLModelInstance(Instance);
     var output = instance.Output;
-    string outColumnType = output != null ? MLModelInstanceHelper.TemplateKeyForOutputType(output.ColumnType) : "Numeric";
-	string outValue = output != null ? MLModelInstanceHelper.TemplateValueForOutputAttValue(output) : "'0'";
+    string outColumnType = MLModelInstanceHelper.TemplateKeyForOutputType(output);
+	string outValue = MLModelInstanceHelper.TemplateValueForOutputAttValue(output);
 %>
 
 <Part type="1d8aeb5a-6e98-45a7-92d2-d8de7384e432">


### PR DESCRIPTION
Output value on DataProvider is not making a "ToString" when the Output Type is Label (e.g. by defining the output as Label with a Numeric-based attribute, it raises an exception because Label is String-based)